### PR TITLE
Add vitest scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",


### PR DESCRIPTION
## Summary
- expose testing scripts from `src/test/README.md`
- add `vitest` scripts to `package.json`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run test:watch` *(fails: vitest not found)*
- `npm run test:coverage` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889377ce3b0832eaf6b74a0b19a3d7a