### PR TITLE
Fix dev server command in Dockerfile snippet

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -438,7 +438,7 @@ RUN git config --global url."https://github.com/".insteadOf "git@github.com:"
 
 EXPOSE 3000 8080 9090
 
-CMD ["npm", "start"]
+CMD ["npm", "run", "dev"]
 ```
 
 ### Kubernetes Configuration


### PR DESCRIPTION
## Summary
- update `docs/AGENTS.md` Dockerfile snippet to use `npm run dev`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6889399becbc832eaff5f19b355da085