### PR TITLE
Use env vars for Supabase config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for IoT Agent Mesh
+SUPABASE_URL=
+SUPABASE_PUBLISHABLE_KEY=

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ $ npm install
 
 # 3. Copy and configure environment variables
 $ cp .env.example .env
-# Fill in SUPABASE_URL and SUPABASE_ANON_KEY
+# Fill in SUPABASE_URL and SUPABASE_PUBLISHABLE_KEY
 
 # 4. Start development server
 $ npm run dev

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -3,8 +3,8 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://tuevghmlxosxuszxjral.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InR1ZXZnaG1seG9zeHVzenhqcmFsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDQzMjAxNjgsImV4cCI6MjA1OTg5NjE2OH0.1-ObhemhffJuvAwrdyNDFjBt_lnlsuvk4R0VFPHrR5g";
+const SUPABASE_URL = process.env.SUPABASE_URL as string;
+const SUPABASE_PUBLISHABLE_KEY = process.env.SUPABASE_PUBLISHABLE_KEY as string;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";


### PR DESCRIPTION
## Summary
- update Supabase client to read credentials from `process.env`
- document required variables in `.env.example`
- update README quickstart instructions

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68893c98e2e8832eabd63e30dbc7258e