### PR TITLE
Add env example and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Example environment configuration
+# Copy this file to `.env` and replace the placeholder values.
+
+# Supabase configuration
+SUPABASE_URL=
+SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+
+# Vite client variables
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=
+
+# IoT Agent Mesh API configuration
+IOT_AGENT_MESH_URL=
+IOT_AGENT_MESH_API_KEY=
+
+# Stripe
+STRIPE_SECRET_KEY=
+
+# Webhooks
+IOT_MESH_WEBHOOK_SECRET=

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ $ npm install
 
 # 3. Copy and configure environment variables
 $ cp .env.example .env
-# Fill in SUPABASE_URL and SUPABASE_ANON_KEY
+# Fill in SUPABASE_URL, SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY and other
+# placeholders in the .env file
 
 # 4. Start development server
 $ npm run dev

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -333,6 +333,8 @@ agent:
 
 ### Environment Variables
 
+See `.env.example` in the project root for the list of required variables.
+
 ```bash
 # Internet Access Configuration
 export INTERNET_ACCESS_ENABLED=true
@@ -615,7 +617,7 @@ cd iot-testing-agents
 
 # Set environment variables
 cp .env.example .env
-# Edit .env with your specific values
+# Edit .env with your Supabase keys and other required values
 
 # Install dependencies
 npm install


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholders
- update README with instructions for configuring all environment variables
- update docs/AGENTS.md to reference `.env.example`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68893ca5af2c832e95d1ac3e61a2c746