### PR TITLE
Add Node version guidance

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -608,6 +608,8 @@ module.exports = IoTTestingAgentController;
 
 ### 1. Environment Setup
 
+This project has been tested with **Node.js 18**. Using Node 18 or later is recommended.
+
 ```bash
 # Clone the configuration
 git clone https://github.com/your-org/iot-testing-agents.git

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Summary
- mention Node 18 in docs/AGENTS.md
- add `engines` field to package.json

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688942dddf04832ebe628197b04e0300