### PR TITLE
Integrate dependency check with npm scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       run: ./scripts/setup.sh
     
     - name: Verify dependencies
-      run: node scripts/check-deps.js
+      run: node scripts/check-deps.cjs
     
     - name: Run tests
       run: npm test

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ $ cd iotagentmesh
 
 # 2. Run setup script (installs dependencies and verifies environment)
 $ ./scripts/setup.sh
+# Rerun this script whenever dependencies change and before running tests or linting
 
 # 3. Copy and configure environment variables
 $ cp .env.example .env

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
+    "pretest": "node scripts/check-deps.cjs",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest watch",

--- a/scripts/check-deps.cjs
+++ b/scripts/check-deps.cjs
@@ -18,7 +18,7 @@ function main() {
   
   if (missing.length > 0) {
     console.error('❌ Missing critical dependencies:', missing.join(', '));
-    console.error('Run "npm install" to install dependencies');
+    console.error('Run "./scripts/setup.sh" to install dependencies');
     process.exit(1);
   }
   


### PR DESCRIPTION
## Summary
- rename `check-deps.js` to `check-deps.cjs`
- add a `pretest` hook in `package.json` to verify dependencies
- update workflow to call the renamed script
- clarify quickstart docs to rerun setup script as needed
- update check-deps message to reference setup script

## Testing
- `npm test` *(fails: Missing dependencies)*
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_688940cf2c84832e96f2b46a1e223bbd