### PR TITLE
feat(api-gateway): forward data requests to api-data

### DIFF
--- a/supabase/functions/api-gateway/handlers/data.test.ts
+++ b/supabase/functions/api-gateway/handlers/data.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Stub global Deno for tests
+vi.stubGlobal('Deno', { env: { get: vi.fn(() => '') } });
+
+const invokeMock = vi.fn();
+const getUserMock = vi.fn();
+const singleMock = vi.fn();
+
+vi.mock('https://esm.sh/@supabase/supabase-js@2', () => ({
+  createClient: () => ({
+    auth: { getUser: getUserMock },
+    from: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: singleMock,
+    functions: { invoke: invokeMock }
+  })
+}));
+
+import { handleData } from './data.ts';
+
+describe('handleData', () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    getUserMock.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    singleMock.mockResolvedValue({ data: { organization_id: 'org-1', role: 'admin' }, error: null });
+  });
+
+  it('forwards device readings path to api-data', async () => {
+    invokeMock.mockResolvedValue({ data: { ok: true }, error: null, status: 200 });
+
+    const req = new Request('https://example.com/api/data/devices/dev123/readings', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' }
+    });
+
+    await handleData(req, '/api/data/devices/dev123/readings');
+
+    expect(invokeMock).toHaveBeenCalledWith('api-data', expect.objectContaining({
+      path: 'devices/dev123/readings',
+      method: 'GET'
+    }));
+  });
+
+  it('forwards bucket data path to api-data', async () => {
+    invokeMock.mockResolvedValue({ data: { ok: true }, error: null, status: 200 });
+
+    const body = { value: 1 };
+    const req = new Request('https://example.com/api/data/data-buckets/bucket1/data', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    });
+
+    await handleData(req, '/api/data/data-buckets/bucket1/data');
+
+    expect(invokeMock).toHaveBeenCalledWith('api-data', expect.objectContaining({
+      path: 'data-buckets/bucket1/data',
+      method: 'POST',
+      body
+    }));
+  });
+});
+

--- a/supabase/functions/api-gateway/handlers/data.ts
+++ b/supabase/functions/api-gateway/handlers/data.ts
@@ -1,0 +1,77 @@
+import { corsHeaders } from '../../_shared/cors.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+export async function handleData(req: Request, path: string): Promise<Response> {
+  const supabaseClient = createClient(
+    Deno.env.get('SUPABASE_URL') ?? '',
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+  );
+
+  try {
+    const url = new URL(req.url);
+    const segments = path.replace('/api/data', '').split('/').filter(Boolean);
+
+    // Authentication and organization logic copied from devices handler
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Missing authorization header' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const token = authHeader.replace('Bearer ', '');
+    const { data: { user }, error: authError } = await supabaseClient.auth.getUser(token);
+
+    if (authError || !user) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Invalid authentication token' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const { data: orgMember, error: orgError } = await supabaseClient
+      .from('organization_members')
+      .select('organization_id, role')
+      .eq('user_id', user.id)
+      .single();
+
+    if (orgError || !orgMember) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'User not associated with any organization' }),
+        { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const organizationId = orgMember.organization_id;
+    void organizationId; // currently unused but retained for parity
+
+    const body = req.method === 'GET' ? undefined : await req.json();
+
+    const { data, error: invokeError, status } = await supabaseClient.functions.invoke('api-data', {
+      body,
+      headers: { Authorization: authHeader },
+      method: req.method,
+      path: segments.join('/'),
+      query: Object.fromEntries(url.searchParams.entries()),
+    });
+
+    if (invokeError) {
+      return new Response(
+        JSON.stringify({ success: false, error: invokeError.message ?? 'Failed to process data request' }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    return new Response(
+      JSON.stringify(data),
+      { status: status ?? 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  } catch (error) {
+    console.error('Error in data handler:', error);
+    return new Response(
+      JSON.stringify({ success: false, error: 'Internal server error' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+}

--- a/supabase/functions/api-gateway/router.ts
+++ b/supabase/functions/api-gateway/router.ts
@@ -5,6 +5,7 @@ import { handleEndpoints } from './handlers/endpoints.ts';
 import { handleProducts } from './handlers/products.ts';
 import { handleProfiles } from './handlers/profiles.ts';
 import { handleApiKeys } from './handlers/keys.ts';
+import { handleData } from './handlers/data.ts';
 import { RouteHandler } from './types.ts';
 
 export function createRouter() {
@@ -23,6 +24,8 @@ export function createRouter() {
   routes.set('/api/products/*', handleProducts);
   routes.set('/api/profiles', handleProfiles);
   routes.set('/api/profiles/*', handleProfiles);
+  routes.set('/api/data', handleData);
+  routes.set('/api/data/*', handleData);
   
   // Add API keys routes
   routes.set('/api/keys', handleApiKeys);


### PR DESCRIPTION
## Summary
- add data handler that maps gateway requests and forwards them to `api-data`
- register `/api/data` routes in the API gateway router
- add unit tests checking device and bucket path forwarding

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install vitest@3.2.4` *(fails: 403 Forbidden from registry)*


------
https://chatgpt.com/codex/tasks/task_e_68ac88f0314c832e82bd2cf18ccd155b