### PR TITLE
Disable JWT verification for api-mcp function

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -22,7 +22,7 @@ enable_email_autoconfirm = false
 verify_jwt = false
 
 [functions.api-mcp]
-verify_jwt = true
+verify_jwt = false
 
 [functions.create-checkout]
 verify_jwt = true


### PR DESCRIPTION
## Summary
- disable JWT verification for the `api-mcp` function in Supabase config

## Testing
- `npm test` *(fails: see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68b472ca9140832ebd074914d9aab5ff