### PR TITLE
feat: add endpoint parameter type

### DIFF
--- a/src/components/endpoints/EndpointCard.tsx
+++ b/src/components/endpoints/EndpointCard.tsx
@@ -5,7 +5,16 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { Switch } from '@/components/ui/switch';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { Edit, MoreHorizontal, Play, Trash2 } from 'lucide-react';
-import { EndpointConfig, EmailEndpointConfig, TelegramEndpointConfig, WebhookEndpointConfig, DeviceActionEndpointConfig, IftttEndpointConfig, WhatsappEndpointConfig } from '@/types/endpoint';
+import {
+  EndpointConfig,
+  EmailEndpointConfig,
+  TelegramEndpointConfig,
+  WebhookEndpointConfig,
+  DeviceActionEndpointConfig,
+  IftttEndpointConfig,
+  WhatsappEndpointConfig,
+  isEndpointParameters,
+} from '@/types/endpoint';
 
 // Type guards for endpoint configurations
 const isEmailConfig = (config: unknown): config is EmailEndpointConfig => {
@@ -21,7 +30,13 @@ const isWebhookConfig = (config: unknown): config is WebhookEndpointConfig => {
 };
 
 const isDeviceActionConfig = (config: unknown): config is DeviceActionEndpointConfig => {
-  return typeof config === 'object' && config !== null && 'target_device_id' in config && 'action' in config;
+  if (typeof config !== 'object' || config === null) return false;
+  const c = config as DeviceActionEndpointConfig;
+  return (
+    typeof c.target_device_id === 'string' &&
+    typeof c.action === 'string' &&
+    (c.parameters === undefined || isEndpointParameters(c.parameters))
+  );
 };
 
 const isIftttConfig = (config: unknown): config is IftttEndpointConfig => {

--- a/src/components/endpoints/FormSections/DeviceActionConfigSection.tsx
+++ b/src/components/endpoints/FormSections/DeviceActionConfigSection.tsx
@@ -4,7 +4,7 @@ import { FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/comp
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { UseFormReturn } from 'react-hook-form';
-import { EndpointFormData } from '@/types/endpoint';
+import { EndpointFormData, isEndpointParameters } from '@/types/endpoint';
 
 interface DeviceActionConfigSectionProps {
   form: UseFormReturn<EndpointFormData>;
@@ -51,11 +51,19 @@ export function DeviceActionConfigSection({ form }: DeviceActionConfigSectionPro
               <Textarea 
                 placeholder={'{\n  "value": true\n}'}
                 className="min-h-[100px] font-mono"
-                value={typeof field.value === 'object' ? JSON.stringify(field.value, null, 2) : field.value || ''}
+                value={
+                  typeof field.value === 'object'
+                    ? JSON.stringify(field.value, null, 2)
+                    : field.value || ''
+                }
                 onChange={(e) => {
                   try {
-                    const params = e.target.value ? JSON.parse(e.target.value) : {};
-                    field.onChange(params);
+                    const parsed = e.target.value ? JSON.parse(e.target.value) : {};
+                    if (isEndpointParameters(parsed)) {
+                      field.onChange(parsed);
+                    } else {
+                      field.onChange(e.target.value);
+                    }
                   } catch {
                     field.onChange(e.target.value);
                   }

--- a/src/types/endpoint.ts
+++ b/src/types/endpoint.ts
@@ -32,10 +32,27 @@ export interface WebhookEndpointConfig {
   body_template?: string;
 }
 
+export type EndpointParameterValue = string | number | boolean | null;
+export type EndpointParameters = Record<string, EndpointParameterValue>;
+
+export function isEndpointParameters(value: unknown): value is EndpointParameters {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Object.values(value as Record<string, unknown>).every(
+      (v) =>
+        typeof v === 'string' ||
+        typeof v === 'number' ||
+        typeof v === 'boolean' ||
+        v === null
+    )
+  );
+}
+
 export interface DeviceActionEndpointConfig {
   target_device_id: string;
   action: string;
-  parameters?: Record<string, string | number | boolean | null>;
+  parameters?: EndpointParameters;
 }
 
 export interface IftttEndpointConfig {

--- a/supabase/functions/trigger-endpoint/index.ts
+++ b/supabase/functions/trigger-endpoint/index.ts
@@ -2,6 +2,8 @@
 import { createClient, type SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2.39.6'
 import { corsHeaders } from '../_shared/cors.ts'
 import type { Database } from '../_shared/database.types.ts'
+import type { EndpointParameters } from '../../../src/types/endpoint.ts'
+import { isEndpointParameters } from '../../../src/types/endpoint.ts'
 
 // Get Supabase client
 const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? ''
@@ -45,7 +47,7 @@ interface WhatsappEndpointConfig {
 interface DeviceActionEndpointConfig {
   target_device_id: string
   action: string
-  parameters?: Record<string, string | number | boolean | null>
+  parameters?: EndpointParameters
 }
 
 interface IftttEndpointConfig {
@@ -89,7 +91,13 @@ function isWhatsappEndpointConfig(config: unknown): config is WhatsappEndpointCo
 
 function isDeviceActionEndpointConfig(config: unknown): config is DeviceActionEndpointConfig {
   const c = config as DeviceActionEndpointConfig
-  return typeof config === 'object' && config !== null && typeof c.target_device_id === 'string' && typeof c.action === 'string'
+  return (
+    typeof config === 'object' &&
+    config !== null &&
+    typeof c.target_device_id === 'string' &&
+    typeof c.action === 'string' &&
+    (c.parameters === undefined || isEndpointParameters(c.parameters))
+  )
 }
 
 function isIftttEndpointConfig(config: unknown): config is IftttEndpointConfig {


### PR DESCRIPTION
## Summary
- define `EndpointParameters` and runtime guard
- validate device action parameters in forms and server handler

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b4a66afb9c832e98cdf8483c5fc250