### PR TITLE
feat: add Postman collection typing

### DIFF
--- a/src/services/api/iotAgentMeshCollectionService.ts
+++ b/src/services/api/iotAgentMeshCollectionService.ts
@@ -32,7 +32,7 @@ export interface EndpointParameter {
   enum_values?: string[];
 }
 
-interface PostmanCollection {
+export interface PostmanCollection {
   info: {
     name: string;
     description: string;
@@ -627,7 +627,7 @@ export class IoTAgentMeshCollectionService {
   }
 
   downloadPostmanCollection(collectionId: string): void {
-    const postmanCollection = this.generatePostmanCollection(collectionId);
+    const postmanCollection: PostmanCollection | null = this.generatePostmanCollection(collectionId);
     if (!postmanCollection) return;
 
     const blob = new Blob([JSON.stringify(postmanCollection, null, 2)], {


### PR DESCRIPTION
## Summary
- add exported PostmanCollection interface for IoTAgentMeshCollectionService
- type downloaded Postman collection and access name without `any`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b4a78e9f50832ea98eb08ac75b41cf