### PR TITLE
Validate endpoint configuration with runtime schema

### DIFF
--- a/src/services/endpoints/baseEndpointService.ts
+++ b/src/services/endpoints/baseEndpointService.ts
@@ -1,18 +1,8 @@
 
-import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
+import type { Database } from '@/integrations/supabase/types';
 
-export interface SupabaseEndpoint {
-  id: string;
-  name: string;
-  description: string | null;
-  type: string;
-  organization_id: string;
-  enabled: boolean;
-  configuration: Record<string, unknown>;
-  created_at: string;
-  updated_at: string;
-}
+export type SupabaseEndpoint = Database['public']['Tables']['endpoints']['Row'];
 
 export const handleServiceError = (error: unknown, operation: string): void => {
   console.error(`Error in ${operation}:`, error);

--- a/src/services/endpoints/createEndpointService.ts
+++ b/src/services/endpoints/createEndpointService.ts
@@ -2,6 +2,7 @@
 import { supabase } from '@/integrations/supabase/client';
 import { EndpointConfig, EndpointFormData } from '@/types/endpoint';
 import { SupabaseEndpoint, handleServiceError } from './baseEndpointService';
+import { endpointConfigurationSchema } from './endpointConfigSchema';
 import { toast } from 'sonner';
 
 /**
@@ -20,7 +21,6 @@ export async function createEndpoint(
       return null;
     }
     
-    // Using generic query to avoid TypeScript issues
     const { error, data } = await supabase
       .from('endpoints')
       .insert({
@@ -31,10 +31,10 @@ export async function createEndpoint(
         enabled: endpointData.enabled,
         configuration: endpointData.configuration || {},
         created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString()
+        updated_at: new Date().toISOString(),
       })
       .select('*')
-      .single();
+      .single<SupabaseEndpoint>();
 
     if (error) {
       console.error('Error creating endpoint:', error);
@@ -50,10 +50,9 @@ export async function createEndpoint(
 
     console.log('Created endpoint successfully:', data);
     toast.success('Endpoint created successfully');
-    
-    // First convert to unknown, then to the expected type to satisfy TypeScript
-    // This is safe because we know the shape of the configuration matches our endpoint types
-    const typedConfiguration = (data.configuration as unknown) as EndpointConfig['configuration'];
+
+    const typedConfiguration: EndpointConfig['configuration'] =
+      endpointConfigurationSchema.parse(data.configuration);
     
     return {
       id: data.id,

--- a/src/services/endpoints/endpointConfigSchema.ts
+++ b/src/services/endpoints/endpointConfigSchema.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+
+const emailEndpointSchema = z.object({
+  to: z.array(z.string()),
+  subject: z.string(),
+  body_template: z.string(),
+});
+
+const telegramEndpointSchema = z.object({
+  bot_token: z.string(),
+  chat_id: z.string(),
+  message_template: z.string(),
+});
+
+const webhookEndpointSchema = z.object({
+  url: z.string(),
+  method: z.enum(['GET', 'POST', 'PUT', 'DELETE']),
+  headers: z.record(z.string()).optional(),
+  body_template: z.string().optional(),
+});
+
+const deviceActionEndpointSchema = z.object({
+  target_device_id: z.string(),
+  action: z.string(),
+  parameters: z.record(z.union([z.string(), z.number(), z.boolean(), z.null()])).optional(),
+});
+
+const iftttEndpointSchema = z.object({
+  webhook_key: z.string(),
+  event_name: z.string(),
+  value1: z.string().optional(),
+  value2: z.string().optional(),
+  value3: z.string().optional(),
+});
+
+const whatsappEndpointSchema = z.object({
+  phone_number_id: z.string(),
+  access_token: z.string(),
+  to_phone_number: z.string(),
+  message_template: z.string(),
+});
+
+export const endpointConfigurationSchema = z.union([
+  emailEndpointSchema,
+  telegramEndpointSchema,
+  webhookEndpointSchema,
+  deviceActionEndpointSchema,
+  iftttEndpointSchema,
+  whatsappEndpointSchema,
+]);
+
+export type EndpointConfiguration = z.infer<typeof endpointConfigurationSchema>;
+

--- a/src/services/endpoints/fetchEndpointService.ts
+++ b/src/services/endpoints/fetchEndpointService.ts
@@ -2,37 +2,40 @@
 import { supabase } from '@/integrations/supabase/client';
 import { EndpointConfig } from '@/types/endpoint';
 import { SupabaseEndpoint, handleServiceError } from './baseEndpointService';
+import { endpointConfigurationSchema } from './endpointConfigSchema';
 
 /**
  * Fetch all endpoints for an organization
  */
 export async function fetchEndpoints(organizationId: string): Promise<EndpointConfig[]> {
   try {
-    // Using generic query to avoid TypeScript issues
     const { data, error } = await supabase
       .from('endpoints')
       .select('*')
-      .eq('organization_id', organizationId) as { 
-        data: SupabaseEndpoint[] | null; 
-        error: unknown; 
-      };
+      .eq('organization_id', organizationId)
+      .returns<SupabaseEndpoint[]>();
     
     if (error) {
       handleServiceError(error, 'fetching endpoints');
       return [];
     }
     
-    return (data || []).map(endpoint => ({
-      id: endpoint.id,
-      name: endpoint.name,
-      description: endpoint.description || undefined,
-      type: endpoint.type as EndpointConfig['type'],
-      organization_id: endpoint.organization_id,
-      enabled: endpoint.enabled,
-      configuration: endpoint.configuration as unknown as EndpointConfig['configuration'],
-      created_at: endpoint.created_at,
-      updated_at: endpoint.updated_at
-    }));
+    return (data || []).map(endpoint => {
+      const configuration: EndpointConfig['configuration'] =
+        endpointConfigurationSchema.parse(endpoint.configuration);
+
+      return {
+        id: endpoint.id,
+        name: endpoint.name,
+        description: endpoint.description || undefined,
+        type: endpoint.type as EndpointConfig['type'],
+        organization_id: endpoint.organization_id,
+        enabled: endpoint.enabled,
+        configuration,
+        created_at: endpoint.created_at,
+        updated_at: endpoint.updated_at,
+      };
+    });
   } catch (error) {
     handleServiceError(error, 'fetchEndpoints');
     return [];


### PR DESCRIPTION
## Summary
- define `SupabaseEndpoint` using generated Supabase table types
- add Zod schema for endpoint configurations and validate insert/fetch results
- remove `as unknown` casts so configuration is typed as `EndpointConfig['configuration']`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4a9ca6b20832e97c40ea6477bb3aa